### PR TITLE
bug: Add location reload to remove callback

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -44,8 +44,9 @@
                             .map(box => box.dataset.tabIds.split(',')
                             .map(val => Number(val)))
                             .flat()
-    chrome.tabs.remove(checkedTabIds)
-    window.location.reload()
+    chrome.tabs.remove(checkedTabIds, () => {
+      window.location.reload()
+    })
   })
 
 

--- a/popup.js
+++ b/popup.js
@@ -1,12 +1,12 @@
 (()  => {
-  let tabsData = []
-  const closeBtn = document.getElementById('close')
-  const GET_DOMAIN_REGEX = /^(?:https?:\/\/)?(?:[^@\n]+@)?(?:www\.)?([^:\/\n?]+)/img
+  const closeBtn          = document.getElementById('close')
+  const GET_DOMAIN_REGEX  = /^(?:https?:\/\/)?(?:[^@\n]+@)?(?:www\.)?([^:\/\n?]+)/img
+  let tabsData            = []
 
   const partitionTabs = (tabs) => {
     tabs.map((tab) => {
       const matchedUrl = tab.url.match(GET_DOMAIN_REGEX)[0]
-      const sameTab = tabsData.find(t => t.url === matchedUrl)
+      const sameTab    = tabsData.find(t => t.url === matchedUrl)
       if (sameTab) {
         sameTab.tabIds.push(tab.id)
       } else {
@@ -22,17 +22,17 @@
   const renderTabList = (tabsData) => {
     const tabsEl = document.getElementsByClassName('tabs')[0]
     tabsData.map((tab, idx) => {
-      const tabEl = document.createElement('div')
-      tabEl.className = 'tab'
-      const checkboxEl = document.createElement('input')
-      checkboxEl.name = 'tab'
-      checkboxEl.type = "checkbox"
-      checkboxEl.id = idx
-      checkboxEl.value = tab.url
+      const tabEl       = document.createElement('div')
+      tabEl.className   = 'tab'
+      const checkboxEl  = document.createElement('input')
+      checkboxEl.name   = 'tab'
+      checkboxEl.type   = "checkbox"
+      checkboxEl.id     = idx
+      checkboxEl.value  = tab.url
       checkboxEl.dataset.tabIds = tab.tabIds.join(',')
-      const label = document.createElement('label')
-      label.htmlFor = checkboxEl.id
-      label.innerText = tab.url
+      const label       = document.createElement('label')
+      label.htmlFor     = checkboxEl.id
+      label.innerText   = tab.url
       tabEl.appendChild(checkboxEl)
       tabEl.appendChild(label)
       tabsEl.appendChild(tabEl)
@@ -48,7 +48,6 @@
       window.location.reload()
     })
   })
-
 
   window.onload = () => {
     chrome.tabs.query({}, partitionTabs)


### PR DESCRIPTION
This PR address a bug where we were not utilizing the callback api of `chrome.tabs.remove`, so there was a race condition where we were reloading the chrome extension before we ended up removing the tabs. This caused the chrome extension to show removed tabs within the list. 